### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [microhn](https://github.com/stubailo/microhn) - Simple Hacker News client built on top of GraphQLHub
 * [Apollo Web&Mobile Universal Starter Kit with Hot Code Reload](https://github.com/sysgears/apollo-universal-starter-kit) -  Apollo, GraphQL, React, React Native, Expo, Redux, Express, SQL and Twitter Bootstrap. Hot Code Reload of back end & front end using Webpack and Hot Module Replacement.
 * [Building Decoupled Sites and Apps with GraphQL and Next.js](https://malloc.fi/building-decoupled-sites-and-apps-with-graphql-and-next-js)
+* [Graphql-Yoga-Subscriptions ](https://github.com/ronal2do/graphql-yoga-dataloader-subscriptions) Example of using subscriptions with graphql-yoga and dataloader
+
 
 <a name="example-ts" />
 


### PR DESCRIPTION
Add graphql-yoga-dataloader-subscriptions

**[link](https://github.com/ronal2do/graphql-yoga-dataloader-subscriptions)**

Simple and super scalable GraphQL Subscriptions server with MongoDB as a database. As server middleware has been used Graphcool Playground which gives automatic schema reloading and better support for GraphQL Subscriptions.

